### PR TITLE
Add support for Travis CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,1 @@
+language: clojure

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/sfx/gel.svg?branch=travis-ci)](https://travis-ci.org/sfx/gel)
+
 # Gel
 
 A Clojure implementation of the [Liquid](https://github.com/shopify/liquid) template engine.


### PR DESCRIPTION
Like we did with [schema-contrib](https://github.com/sfx/schema-contrib). I have already "turned this on." So any merge into master should trigger a build on Travis CI.
